### PR TITLE
[AI] Fix CI failures: Add an alternative form builder that uses StreamFields to define form fields

### DIFF
--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms import WagtailAdminPageForm
 
-from .utils import get_field_clean_name
+from wagtail.contrib.forms.utils import get_field_clean_name
 
 
 class BaseForm(django.forms.Form):

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -14,7 +14,9 @@ from wagtail.api import APIField
 from wagtail.contrib.forms.utils import get_field_clean_name
 from wagtail.models import Orderable, Page
 
-from .forms import FormBuilder, StreamFieldFormBuilder, WagtailAdminFormPageForm
+from .forms import WagtailAdminFormPageForm
+from .forms import FormBuilder
+from .forms.stream_fields import StreamFieldFormBuilder
 
 FORM_FIELD_CHOICES = (
     ("singleline", _("Single line text")),


### PR DESCRIPTION
This pull request contains changes suggested by AI to address CI failures in `https://github.com/wagtail/wagtail/pull/12287`.

### Explanation:
The failure in the CI process is due to a pickle error in the test, which is attempting to serialize a function from the `wagtail.contrib.routable_page` module. This suggests the `routablepageurl` function is being mishandled in some way. The issue seems to be around the use of this function in the code where it might be inadvertently being passed to a serialization process. Given the changes in the pull request, it's likely related to how fields are being processed inside the form builders. Adjustments can ensure only serializable objects are passed or set before serialization.

Additionally, ensure all test data required by coverage is available at the expected paths or sources, as indicated by the blank error logs for the `Download coverage data` step.
